### PR TITLE
Fix/nottrimmedheader

### DIFF
--- a/Resources/Views/results.leaf
+++ b/Resources/Views/results.leaf
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="fr">
 <head>
-	<meta http-equiv="Content-Type" Content="text/html; charset=UTF-8">
+	<meta http-equiv="Content-Type" Content="text/html; charset=UTF-16">
 	<link rel="stylesheet" type="text/css" href="styles.css" />
 	<link href='http://fonts.googleapis.com/css?family=Rokkitt' rel='stylesheet' type='text/css'>
 </head>
@@ -33,9 +33,8 @@
 	<div class='lang_header'><a name='#(element.language.code)'>#(element.language.localized)</a><div class='selectall'>select all</div></div>
 	<div class='lang'>
         <textarea>#for(entry in element.entries){#if(entry.type == "comment"){/* #(entry.value) */
-}#if(entry.type == "blank"){
-}#if(entry.type == "translation"){"#(entry.key)" = "#(entry.value)";
-}}</textarea>
+}#if(entry.type == "blank"){}
+#if(entry.type == "translation"){"#(entry.key)" = "#(entry.value)";}}</textarea>
 	</div>
 	}
 </div>

--- a/Resources/Views/results.leaf
+++ b/Resources/Views/results.leaf
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="fr">
 <head>
-	<meta http-equiv="Content-Type" Content="text/html; charset=UTF-16">
+	<meta http-equiv="Content-Type" Content="text/html; charset=UTF-8">
 	<link rel="stylesheet" type="text/css" href="styles.css" />
 	<link href='http://fonts.googleapis.com/css?family=Rokkitt' rel='stylesheet' type='text/css'>
 </head>

--- a/Sources/App/Controllers/CSVParserController.swift
+++ b/Sources/App/Controllers/CSVParserController.swift
@@ -21,7 +21,7 @@ final class CSVParserController {
             guard let fileContent = String(data: file.csv, encoding: .utf8) else {
                 throw Abort(.badRequest, reason: "Unreadable CSV file")
             }
-            let parser = CSVParser(csvData: fileContent, separator: ",")
+            let parser = CSVParser(csvData: fileContent, separator: ";")
             let lines = try parser.parse()
             let localizer = LocalizeDocument(csvLines: lines)
             return try localizer.parseDocument()

--- a/Sources/App/Models/LocalizeDocument.swift
+++ b/Sources/App/Models/LocalizeDocument.swift
@@ -39,9 +39,10 @@ struct LocalizeDocument {
 		try csvLines.dropFirst().forEach { columns in
 			lineNumber += 1
             guard let key = columns.first?.trimmingCharacters(in: .whitespacesAndNewlines), !key.isEmpty
-			else { return }
-			// Here, comment line
-			else if let match = self.commentRegex.firstMatch(in: key, options: [], range: NSRange(location: 0, length: key.count)) {
+			else {
+                return
+            }
+            if let match = self.commentRegex.firstMatch(in: key, options: [], range: NSRange(location: 0, length: key.count)) {
 				if let range = Range(match.range(at: 1), in: key) {
 					let commentString = String(key[range])
 					languages.forEach { entries[$0]?.append(.comment(commentString)) }

--- a/Sources/App/Models/LocalizeDocument.swift
+++ b/Sources/App/Models/LocalizeDocument.swift
@@ -38,13 +38,8 @@ struct LocalizeDocument {
 		var lineNumber: Int = 0
 		try csvLines.dropFirst().forEach { columns in
 			lineNumber += 1
-			guard let key = columns.first?.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let key = columns.first?.trimmingCharacters(in: .whitespacesAndNewlines), !key.isEmpty
 			else { return }
-			
-			// Here, blank line
-			if key.count == 0 {
-				languages.forEach { entries[$0]?.append(.blankLine) }
-			}
 			// Here, comment line
 			else if let match = self.commentRegex.firstMatch(in: key, options: [], range: NSRange(location: 0, length: key.count)) {
 				if let range = Range(match.range(at: 1), in: key) {
@@ -58,7 +53,8 @@ struct LocalizeDocument {
 			// Here, real key with translations
 			else {
 				zip(firstLine.dropFirst(), columns.dropFirst()).forEach { code, cell in
-					guard let language = Language(code: code) else { return }
+                    let trimmedCode = code.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+					guard let language = Language(code: trimmedCode) else { return }
 					let escapedCell = cell.replacingOccurrences(of: "\"", with: "\\\"")
 					entries[language]?.append(.translation(key, escapedCell))
 				}


### PR DESCRIPTION
Fix an issue happening when columns header name have extra space character.
Set separator to ";" ( default csv separator in Numbers software), I think we need a field in the UI to set the separator.
results.leaf edited and "!key.isEmpty" condition added to LocalizeDocument to remove extra blank lines
